### PR TITLE
Task show

### DIFF
--- a/frontend/src/components/tasks/task_index.js
+++ b/frontend/src/components/tasks/task_index.js
@@ -1,21 +1,25 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { CheckBox } from 'react-native-elements';
+import TaskShowContainer from './task_show_container';
 
 class TaskIndex extends React.Component {
   constructor(props) {
     super(props);
     this.toggleCompleted = this.toggleCompleted.bind(this);
+    this.navigateToShow = this.navigateToShow.bind(this);
   }
 
   componentWillMount() {
-    // console.log('taksindex.componentWillMount');
-    // // Need to have the owner_id
     this.props.fetchAllTasks(this.props.user.id);
   }
 
   componentWillReceiveProps(newProps) {
     console.log('newProps', newProps);
+  }
+
+  navigateToShow(task) {
+    this.props.navigation.navigate('TaskShow', { taskId: task.id });
   }
 
   toggleCompleted(task) {
@@ -26,7 +30,7 @@ class TaskIndex extends React.Component {
   }
 
   render() {
-    console.log('render');
+    console.log('render, props', this.props);
     return (
       <View>
         <Text>Hi {this.props.user.first_name}</Text>
@@ -36,7 +40,7 @@ class TaskIndex extends React.Component {
                 key={task.id}
                 title={task.title}
                 checked={task.completed}
-                onPress={ this.navigateToShow }
+                onPress={ () => this.navigateToShow(task) }
                 onIconPress={ this.toggleCompleted(task) } />
             ))
           }

--- a/frontend/src/components/tasks/task_index_container.js
+++ b/frontend/src/components/tasks/task_index_container.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
-import { fetchAllTasks, editTask } from '../../actions/task_actions';
-import { fetchUser } from '../../actions/user_actions';
+import {
+  fetchAllTasks,
+  fetchTask,
+  editTask
+} from '../../actions/task_actions';
 import TaskIndex from './task_index';
 
 const mapStateToProps = state => ({
@@ -10,6 +13,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   fetchAllTasks: ownerId => dispatch(fetchAllTasks(ownerId)),
+  fetchTask: taskId => dispatch(fetchTask(taskId)),
   editTask: task => dispatch(editTask(task))
 });
 

--- a/frontend/src/components/tasks/task_show.js
+++ b/frontend/src/components/tasks/task_show.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+class TaskShow extends React.Component {
+  constructor(props) {
+    super(props);
+    console.log('Inside TaskShow: props', props);
+  }
+
+  render() {
+    return (
+      <View>
+        <Text>Hellow out there</Text>
+      </View>
+    );
+  }
+}
+
+export default TaskShow;

--- a/frontend/src/components/tasks/task_show.js
+++ b/frontend/src/components/tasks/task_show.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text } from 'react-native';
-import { CheckBox } from 'react-native-elements';
+import { CheckBox, Button } from 'react-native-elements';
 
 class TaskShow extends React.Component {
   constructor(props) {
@@ -20,10 +20,16 @@ class TaskShow extends React.Component {
     return (
       <View>
         <Text>{task.title}</Text>
-          <CheckBox
-            title={<Text>Completed?</Text>}
-            checked={task.completed}
-            onIconPress={ this.toggleCompleted(task) } />
+        <CheckBox
+          title={"Completed?"}
+          checked={task.completed}
+          onIconPress={this.toggleCompleted(task)} />
+        <Button
+          small
+          backgroundColor='green'
+          icon={{name: 'edit'}}
+          title='Edit Task'
+          onPress={console.log('EDIT THIS!')} />
       </View>
     );
   }

--- a/frontend/src/components/tasks/task_show.js
+++ b/frontend/src/components/tasks/task_show.js
@@ -1,16 +1,29 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import { CheckBox } from 'react-native-elements';
 
 class TaskShow extends React.Component {
   constructor(props) {
     super(props);
-    console.log('Inside TaskShow: props', props);
+    this.toggleCompleted = this.toggleCompleted.bind(this);
+  }
+
+  toggleCompleted(task) {
+    return () => {
+      task.completed = !task.completed;
+      this.props.editTask(task);
+    };
   }
 
   render() {
+    const task = this.props.task;
     return (
       <View>
-        <Text>Hellow out there</Text>
+        <Text>{task.title}</Text>
+          <CheckBox
+            title={<Text>Completed?</Text>}
+            checked={task.completed}
+            onIconPress={ this.toggleCompleted(task) } />
       </View>
     );
   }

--- a/frontend/src/components/tasks/task_show_container.js
+++ b/frontend/src/components/tasks/task_show_container.js
@@ -1,10 +1,13 @@
 import { connect } from 'react-redux';
+import { editTask } from '../../actions/task_actions';
 import TaskShow from './task_show';
 
 const mapStateToProps = (state, ownProps) => ({
   task: state.entities.tasks[ownProps.navigation.state.params.taskId]
 });
 
-const mapDispatchToProps = null;
+const mapDispatchToProps = dispatch => ({
+  editTask: task => dispatch(editTask(task))
+});
 
-export default connect(mapStateToProps, null)(TaskShow);
+export default connect(mapStateToProps, mapDispatchToProps)(TaskShow);

--- a/frontend/src/components/tasks/task_show_container.js
+++ b/frontend/src/components/tasks/task_show_container.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import TaskShow from './task_show';
+
+const mapStateToProps = (state, ownProps) => ({
+  task: state.entities.tasks[ownProps.navigation.state.params.taskId]
+});
+
+const mapDispatchToProps = null;
+
+export default connect(mapStateToProps, null)(TaskShow);

--- a/frontend/src/reducers/tasks_reducer.js
+++ b/frontend/src/reducers/tasks_reducer.js
@@ -6,7 +6,7 @@ const TaskReducer = (state = {}, action) => {
     case TaskActions.RECEIVE_ALL_TASKS:
       return action.tasks.data;
     case TaskActions.RECEIVE_TASK:
-    console.log('action', action);
+      console.log('Inside TaskReducer, RECEIVE_TASK', action);
       return Object.assign({}, state, {[action.task.data.id]: action.task.data});
     default:
       return state;

--- a/frontend/src/routers.js
+++ b/frontend/src/routers.js
@@ -3,7 +3,7 @@ import { StackNavigator } from 'react-navigation';
 import SplashContainer from './components/splash/splash_container';
 import LoginContainer from './components/login/login_container';
 import TaskIndexContainer from './components/tasks/task_index_container';
-import TaskShowContainer from './components/tasks/task_index_container';
+import TaskShowContainer from './components/tasks/task_show_container';
 
 const Routers = StackNavigator(
   {
@@ -21,7 +21,8 @@ const Routers = StackNavigator(
       }
     },
     TaskShow: {
-      screen: TaskShowContainer
+      screen: TaskShowContainer,
+      path: 'api/tasks/:taskId'
     }
   }
 );

--- a/frontend/src/util/task_api_util.js
+++ b/frontend/src/util/task_api_util.js
@@ -7,4 +7,4 @@ export const getTasks = ownerId => axios.get('http://localhost:3000/api/tasks', 
 export const patchTask = task => axios.patch(
   `http://localhost:3000/api/tasks/${task.id}`, { task });
 
-export const getTask = taskId => axios.get(`api/tasks/${ taskId }`);
+export const getTask = taskId => axios.get(`http://localhost:3000/api/tasks/${ taskId }`);


### PR DESCRIPTION
- pass in props through the stack navigator using the path key (see line 25 of routers.js and line 22 of task_index.js)
- installed a checkbox (same as the index items) and an edit button (not linked to anything yet) on TaskShow
- possible refactor: wrote a toggleCheckbox function in TaskShow that's identical to that in TaskIndex (maybe unnecessary)
- NEXT UP: install an Add New Task button to the header of TaskIndex, write a TaskForm that takes user input, route both the Add New Task button from TaskIndex and the Edit Task button from TaskShow to the new form and pass in the current task from Show to prefill the fields if present