### PR TITLE
Add navigateToShow function within TaskShow for children of current task

### DIFF
--- a/frontend/src/components/tasks/task_show.js
+++ b/frontend/src/components/tasks/task_show.js
@@ -23,6 +23,10 @@ class TaskShow extends React.Component {
       this.props.navigation.navigate('TaskForm', { parentId: prop });
     }
   }
+  
+  navigateToShow(task) {
+    this.props.navigation.navigate('TaskShow', { taskId: task.id });
+  }
 
   render() {
     const task = this.props.task;


### PR DESCRIPTION
Fix bug where child task's navigate onPress function doesn't work